### PR TITLE
Add a bit of padding to the bottom of the sponsors panel

### DIFF
--- a/css/cvmp.css
+++ b/css/cvmp.css
@@ -85,6 +85,7 @@ img#venue {
 
 #sponsors .panel-body {
   padding: 0px;
+  padding-bottom: 15px;
 }
 
 .panel h4, .panel h3, .panel h2, .panel h1 {


### PR DESCRIPTION
This adds a bit of padding to the bottom of the sponsors panel. Otherwise, the bottom logo appears right on the grey box line.